### PR TITLE
Change to the new artifactory domain

### DIFF
--- a/examples/server/pom.xml
+++ b/examples/server/pom.xml
@@ -77,7 +77,7 @@
     <repository>
       <id>camunda.com.public</id>
       <name>Camunda Repository</name>
-      <url>https://app.camunda.com/nexus/content/groups/public</url>
+      <url>https://artifacts.camunda.com/artifactory/public/</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -141,12 +141,12 @@
     <repository>
       <id>camunda-nexus</id>
       <name>Camunda Platform community extensions</name>
-      <url>https://app.camunda.com/nexus/content/repositories/camunda-bpm-community-extensions</url>
+      <url>https://artifacts.camunda.com/artifactory/camunda-bpm-community-extensions/</url>
     </repository>
     <snapshotRepository>
       <id>camunda-nexus</id>
       <name>Camunda Platform community extensions snapshots</name>
-      <url>https://app.camunda.com/nexus/content/repositories/camunda-bpm-community-extensions-snapshots</url>
+      <url>https://artifacts.camunda.com/artifactory/camunda-bpm-community-extensions-snapshots/</url>
       <!-- for maven 2 compatibility -->
       <uniqueVersion>true</uniqueVersion>
     </snapshotRepository>

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -47,12 +47,12 @@
     <repository>
       <id>camunda-nexus</id>
       <name>Camunda Platform</name>
-      <url>https://app.camunda.com/nexus/content/repositories/camunda-bpm</url>
+      <url>https://artifacts.camunda.com/artifactory/camunda-bpm/</url>
     </repository>
     <snapshotRepository>
       <id>camunda-nexus</id>
       <name>Camunda Platform snapshots</name>
-      <url>https://app.camunda.com/nexus/content/repositories/camunda-bpm-snapshots</url>
+      <url>https://artifacts.camunda.com/artifactory/camunda-bpm-snapshots/</url>
       <uniqueVersion>true</uniqueVersion>
     </snapshotRepository>
   </distributionManagement>
@@ -61,7 +61,7 @@
     <repository>
       <id>camunda.com.public</id>
       <name>Camunda Repository</name>
-      <url>https://app.camunda.com/nexus/content/groups/public</url>
+      <url>https://artifacts.camunda.com/artifactory/public/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
As announced in [#engineering](https://camunda.slack.com/archives/C01H4NG9XDY/p1648023935192419) slack channel, we created a new Artifactory domain since the nexus one used now is a proxy URL and will be removed in the future. 

Related to INFRA-3106